### PR TITLE
Disable SQLALCHEMY_TRACK_MODIFICATIONS in config

### DIFF
--- a/config.py
+++ b/config.py
@@ -5,6 +5,7 @@ basedir = os.path.abspath(os.path.dirname(__file__))
 class Config:
     SECRET_KEY = os.environ.get('SECRET_KEY') or '594a44b992b3ed67752f7e9807dd4daa'
     SQLALCHEMY_COMMIT_ON_TEARDOWN = True
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
     #BOOTSTRAP_SERVE_LOCAL = True
     MAIL_SERVER = 'smtp.zoho.com'
     MAIL_PORT = 587


### PR DESCRIPTION
Having no setting for this config value emits a warning from the
flask_sqlalchemy package, noting that the default will soon change to False.
(There's some significant overhead having it enabled apparently, and I've
found no evidence that it's used.)
