### PR TITLE
Correct comparison of head-to-head placings

### DIFF
--- a/app/racer/views.py
+++ b/app/racer/views.py
@@ -184,7 +184,7 @@ def head2head():
 
         @staticmethod
         def result_comp(place1, place2):
-            if place1 == place2:
+            if place1 == place2 or not place1:
                 return False
             if not place2:
                 return True


### PR DESCRIPTION
Results with no placing weren't being compared correctly.  When one side had
no result and the other had a result, it was being counted as a head-to-head
win for both parties.