### PR TITLE
Display nothing for Starters column if value is not present.

### DIFF
--- a/app/templates/results.html
+++ b/app/templates/results.html
@@ -83,7 +83,10 @@
             {% endif %}
           </td>
           <td>{{result['course_name']}}</td>
-          <td>{{result['starters']}}</td>
+          <td>
+            {% if result['starters'] is not none %}
+              {{result['starters']}}
+            {% endif %}
           <td>
             {% if result['fast_lap'] is not none %}
               {{result['fast_lap']}}


### PR DESCRIPTION
Specific to the Results view, if the # of starters data was missing from a Race, a value of 'None' would be display.
Now it displays nothing.
Fixes #93