### PR TITLE
Remove duplicitous Point Prime tracking

### DIFF
--- a/app/race/views.py
+++ b/app/race/views.py
@@ -126,9 +126,16 @@ def details(id):
                                           .having(Participant.mar_place > 0)\
                                           .order_by(Participant.mar_place)\
                                           .all()
+
     primes = Prime.query.join(Participant)\
                         .join(Race)\
                         .filter(Race.id == id).all()
+
+    #Let's make a temporary point_prime Prime for display only
+    point_prime_winner = Participant.query.join(Race)\
+                                          .filter(Race.id == id)\
+                                          .filter(Participant.point_prime)\
+                                          .first()
 
     attachments = RaceAttachment.query.join(Race)\
                                       .filter(Race.id == id)\
@@ -139,7 +146,8 @@ def details(id):
                            mar_list=mar_list,
                            dnf_list=dnf_list,
                            primes=primes,
-                           attachments=attachments)
+                           attachments=attachments,
+                           point_prime_winner=point_prime_winner)
 
 
 @race.route('/add/', methods=['GET', 'POST'])
@@ -399,17 +407,6 @@ def add_participant(id):
         flash('Racer ' + participant.racer.name + ' added to race!')
         current_app.logger.info('%s[%d]:%s[%d]', race.name, race.id,
                                 participant.racer.name, participant.id)
-        #Let's also add a Prime of "Point Prime" if necessary
-        if point_prime:
-            participant_id = participant.id
-            name = "Point Prime"
-            prime = Prime(name=name, participant_id=participant_id)
-            db.session.add(prime)
-            db.session.commit()
-            flash('Prime for ' + prime.participant.racer.name + ' added!')
-            current_app.logger.info('%s[%d]:%s[%d]:%s[%d]', race.name, race.id,
-                                    participant.racer.name, participant.id,
-                                    prime.name, prime.id)
  
         if 'submit' in request.form:
             return redirect(url_for('race.details', id=race.id))
@@ -711,11 +708,17 @@ def download_text(id):
     primes = Prime.query.join(Participant)\
                         .join(Race)\
                         .filter(Race.id == id).all()
+
+    point_prime_winner = Participant.query.join(Race)\
+                                          .filter(Race.id == id)\
+                                          .filter(Participant.point_prime)\
+                                          .first()
     textfile = render_template('race/details.txt', race=race,
                                participants=participants,
                                mar_list=mar_list,
                                dnf_list=dnf_list,
-                               primes=primes)
+                               primes=primes,
+                               point_prime_winner=point_prime_winner)
     response = make_response(textfile)
     response.headers['Content-Type'] = "application/octet-stream"
     response.headers['Content-Disposition'] = "inline; filename=cr" +\

--- a/app/race/views.py
+++ b/app/race/views.py
@@ -132,10 +132,10 @@ def details(id):
                         .filter(Race.id == id).all()
 
     #Let's make a temporary point_prime Prime for display only
-    point_prime_winner = Participant.query.join(Race)\
-                                          .filter(Race.id == id)\
-                                          .filter(Participant.point_prime)\
-                                          .first()
+    point_prime_winners = Participant.query.join(Race)\
+                                           .filter(Race.id == id)\
+                                           .filter(Participant.point_prime)\
+                                           .all()
 
     attachments = RaceAttachment.query.join(Race)\
                                       .filter(Race.id == id)\
@@ -147,7 +147,7 @@ def details(id):
                            dnf_list=dnf_list,
                            primes=primes,
                            attachments=attachments,
-                           point_prime_winner=point_prime_winner)
+                           point_prime_winners=point_prime_winners)
 
 
 @race.route('/add/', methods=['GET', 'POST'])
@@ -709,16 +709,16 @@ def download_text(id):
                         .join(Race)\
                         .filter(Race.id == id).all()
 
-    point_prime_winner = Participant.query.join(Race)\
-                                          .filter(Race.id == id)\
-                                          .filter(Participant.point_prime)\
-                                          .first()
+    point_prime_winners = Participant.query.join(Race)\
+                                           .filter(Race.id == id)\
+                                           .filter(Participant.point_prime)\
+                                           .all()
     textfile = render_template('race/details.txt', race=race,
                                participants=participants,
                                mar_list=mar_list,
                                dnf_list=dnf_list,
                                primes=primes,
-                               point_prime_winner=point_prime_winner)
+                               point_prime_winners=point_prime_winners)
     response = make_response(textfile)
     response.headers['Content-Type'] = "application/octet-stream"
     response.headers['Content-Disposition'] = "inline; filename=cr" +\

--- a/app/templates/race/details.html
+++ b/app/templates/race/details.html
@@ -217,7 +217,7 @@ MAR
 {%endif%}
 
 
-{%if primes|length >0%}
+{%if primes|length >0 or point_prime_winner%}
 <h3>
 Primes
 </h3>
@@ -230,6 +230,12 @@ Primes
 </tr>
 </thead>
 <tbody>
+{% if point_prime_winner %}
+<tr>
+<td><a href="{{url_for('racer.details', id=point_prime_winner.racer.id)}}">{{point_prime_winner.racer.name}}</a></td>
+<td>Point Prime</td>
+</tr>
+{% endif %}
 {% for prime in primes%}
 <tr>
 <td><a href="{{url_for('racer.details',id=prime.participant.racer.id)}}">{{prime.participant.racer.name}}</a></td>

--- a/app/templates/race/details.html
+++ b/app/templates/race/details.html
@@ -217,7 +217,7 @@ MAR
 {%endif%}
 
 
-{%if primes|length >0 or point_prime_winner%}
+{%if primes|length >0 or point_prime_winners%}
 <h3>
 Primes
 </h3>
@@ -230,12 +230,12 @@ Primes
 </tr>
 </thead>
 <tbody>
-{% if point_prime_winner %}
+{% for point_prime_winner in point_prime_winners %}
 <tr>
 <td><a href="{{url_for('racer.details', id=point_prime_winner.racer.id)}}">{{point_prime_winner.racer.name}}</a></td>
 <td>Point Prime</td>
 </tr>
-{% endif %}
+{% endfor %}
 {% for prime in primes%}
 <tr>
 <td><a href="{{url_for('racer.details',id=prime.participant.racer.id)}}">{{prime.participant.racer.name}}</a></td>

--- a/app/templates/race/details.txt
+++ b/app/templates/race/details.txt
@@ -64,11 +64,15 @@ MAR Place	Name	Team
 {%- endif -%}
 
 
-{%- if primes|length >0 -%}
+{%- if primes|length >0 or point_prime_winner-%}
 {{nl}}
 Primes
 Name	Prime
 {{nl}}
+{%- if point_prime_winner -%}
+{{point_prime_winner.racer.name}}	Point Prime
+{{nl}}
+{%- endif -%}
 {%- for prime in primes -%}
 {{prime.participant.racer.name}}	{{ prime.name }}
 {{nl}}

--- a/app/templates/race/details.txt
+++ b/app/templates/race/details.txt
@@ -64,15 +64,15 @@ MAR Place	Name	Team
 {%- endif -%}
 
 
-{%- if primes|length >0 or point_prime_winner-%}
+{%- if primes|length >0 or point_prime_winners -%}
 {{nl}}
 Primes
 Name	Prime
 {{nl}}
-{%- if point_prime_winner -%}
+{%- for point_prime_winner in point_prime_winners -%}
 {{point_prime_winner.racer.name}}	Point Prime
 {{nl}}
-{%- endif -%}
+{%- endfor -%}
 {%- for prime in primes -%}
 {{prime.participant.racer.name}}	{{ prime.name }}
 {{nl}}


### PR DESCRIPTION
Previously, when a Participant won the point prime the following would occur:
- The participant had point_prime=True set
- A Prime object was added with the name 'Point Prime'

With this change, we are no longer creating the additional Prime object and inserting it into the database.
The Race view will add an additional row to the Primes table if a Participant has point_prime=True